### PR TITLE
update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5764f10d27b2e93c84f70af5778941b8f4aa1379b2430f85c827e0f5464e8714
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
@@ -19,15 +19,13 @@ build:
 
 requirements:
   host:
-    - python >=3.4
+    - python >=3.5
     - pip
   run:
     - mypy_extensions >=0.4.0,<0.5.0
-    - python >=3.4
-    - typed-ast >=1.2.0,<1.3.0
+    - python >=3.5
+    - typed-ast >=1.3.1,<1.4.0
     - psutil >=5.4.0,<5.5.0
-    # or remove typing and use python >=3.5
-    - typing >=3.5.3
 
 test:
   imports:


### PR DESCRIPTION
bump Python requirement to 3.5, remove typing
update typed-ast bounds to >=1.3.1,<1.4.0
bump build number