### PR TITLE
Enable compiled builds for arm64

### DIFF
--- a/recipe/conda_build_config.yml
+++ b/recipe/conda_build_config.yml
@@ -1,3 +1,0 @@
-# https://conda-forge.org/docs/maintainer/knowledge_base.html#requiring-newer-macos-sdks
-MACOSX_SDK_VERSION:  # [arm64]
-  - '11.0'                 # [arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,8 @@ requirements:
     - mypy_extensions >=0.4.3,<0.5.0
     - typed-ast >=1.4.0,<1.5.0  # [py<38]
     - typing_extensions >=3.7.4
-    - types_toml >=0.0
-    - types_typed_ast >=1.4.0,<1.5.0
+    - types-toml >=0.0
+    - types-typed-ast >=1.4.0,<1.5.0
     - toml
   run:
     - python


### PR DESCRIPTION
There appear to be multiple repos, e.g. 

https://github.com/conda-forge/types_toml-feedstock
https://github.com/conda-forge/types-toml-feedstock

is this intentional?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
