### PR TITLE
Don't use mypyc on osx-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
     - patches/0001-Reduce-amount-of-debug-info-injected-in-extension-mo.patch
 
 build:
-  number: 0
+  number: 1
   script:
-    - export MYPY_USE_MYPYC=1  # [not win]
+    - export MYPY_USE_MYPYC=1  # [not win and not (osx and arm64)]
     - export SETUPTOOLS_USE_DISTUTILS=stdlib  # [not win]
     - set MYPY_USE_MYPYC=1     # [win]
     - set SETUPTOOLS_USE_DISTUTILS=stdlib  # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This fixes #58 by turning off mypyc on osx-arm64 cross-compiling.

Some investigation has shown that the mypyc build creates a strange form of so-file that is not properly signed (and can't be properly signed) and therefore won't work on m1 macs.  I am not sure if this is a cross-compilation issue, or an issue with the mypy build system.  I will investigate further, but in the meantime turning off mypyc will get mypy working correctly on osx-arm64.

<!--
Please add any other relevant info below:
-->
