### PR TITLE
Fix osx arm64 cross

### DIFF
--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -1,5 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,5 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,5 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
     - patches/0001-Reduce-amount-of-debug-info-injected-in-extension-mo.patch
 
 build:
-  number: 1
+  number: 2
   script:
-    - export MYPY_USE_MYPYC=1  # [not win and not (osx and arm64)]
+    - export MYPY_USE_MYPYC=1  # [not win]
     - export SETUPTOOLS_USE_DISTUTILS=stdlib  # [not win]
     - set MYPY_USE_MYPYC=1     # [win]
     - set SETUPTOOLS_USE_DISTUTILS=stdlib  # [win]
@@ -32,7 +32,7 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - {{ compiler('c') }}                    # [not (osx and arm64)]
+    - {{ compiler('c') }}
     # mypy's build imports this module, which has a C extension,
     # so it has to be native to the build platform
     - typed-ast >=1.4.0,<1.5.0               # [build_platform != target_platform and py<38]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This actually fixes #58 with the full solution.  The problem was that the c compiler, which was actually a required dependency for `mypyc`, was excluded from osx-arm64 builds.  However, it was a transient dependency of something else so that's why it was pulled in and everything seemed to compile.  But without the proper dependency in `meta.yaml` _and a rerender_, the compiler version was not properly pinned and there were inconsistent versions used for the native and cross parts of the build.  Long story short (too late!) removing the restriction from the compiler dependency and rerendering to add the correct pins seems to have done the trick.

<!--
Please add any other relevant info below:
-->
