### PR TITLE
Use `{{ compiler('c') }}`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,7 +93,7 @@ outputs:
         - python
       run:
         - {{ pin_subpackage("mypy", exact=True) }}
-        - c-compiler
+        - {{ compiler('c') }}
         - python
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 72382cb609142dba3f04140d016c94b4092bc7b4d98ca718740dc989e5271b8d
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Uses `{{ compiler('c') }}` in `mypyc`'s `requirements/run`.

xref: https://github.com/conda-forge/mypy-feedstock/pull/84#discussion_r1019570098

cc @bollwyvl

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
